### PR TITLE
feat: Replace browser alerts with SweetAlert2 toasts

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
 
 	<link rel="stylesheet" href="src/styles/styles.css">
 
+	<!-- SweetAlert2 CSS -->
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css">
+
 	<title>Address Search</title>
 </head>
 <body>
@@ -89,6 +92,9 @@
 	</main>
 
 	<script src="src/scripts/scripts.js"></script>
+
+	<!-- SweetAlert2 JS -->
+	<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.all.min.js"></script>
 
 </body>
 </html>

--- a/src/scripts/scripts.js
+++ b/src/scripts/scripts.js
@@ -3,7 +3,15 @@
 function getAddress(cep) {
 
 	if(cep == '' || cep.length >= 9 || cep.length <= 7) {
-		alert('Por favor preencha corretamente o campo CEP!')
+		Swal.fire({
+		  toast: true,
+		  position: 'top-end',
+		  icon: 'error',
+		  title: 'Por favor preencha corretamente o campo CEP!',
+		  showConfirmButton: false,
+		  timer: 3000,
+		  timerProgressBar: true
+		})
 	}
 
 	let url = `https://viacep.com.br/ws/${cep}/json/`


### PR DESCRIPTION
Replaced the default browser alert in the CEP validation with a SweetAlert2 toast notification. This provides a more modern and user-friendly experience.

The SweetAlert2 library was added via CDN, and the `getAddress` function in `src/scripts/scripts.js` was updated to use `Swal.fire()` for displaying the error message.